### PR TITLE
simpleJavaTest: add an example where a rule forwards the provider

### DIFF
--- a/simpleJavaTest/basenameConflict/BUILD
+++ b/simpleJavaTest/basenameConflict/BUILD
@@ -7,6 +7,7 @@ java_test(
     deps = [
         "@maven//:junit_junit",
     ],
+    visibility = ["//visibility:public"],
 )
 
 java_test(
@@ -16,4 +17,5 @@ java_test(
     deps = [
         "@maven//:junit_junit",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/simpleJavaTest/forwarded/BUILD.bazel
+++ b/simpleJavaTest/forwarded/BUILD.bazel
@@ -1,0 +1,13 @@
+load(":forward.bzl", "forward")
+
+forward(
+    name = "fwd",
+    dep = "//basenameConflict:basename",
+    testonly = 1,
+)
+
+forward(
+    name = "nested/fwd",
+    dep = "//basenameConflict:nested/basename",
+    testonly = 1,
+)

--- a/simpleJavaTest/forwarded/forward.bzl
+++ b/simpleJavaTest/forwarded/forward.bzl
@@ -1,0 +1,11 @@
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
+def _forward(ctx):
+    return [ctx.attr.dep[JavaInfo]]
+
+forward = rule(
+    implementation = _forward,
+    attrs = {
+        "dep": attr.label(),
+    },
+)


### PR DESCRIPTION
... and, in particular, has a `jdeps` file outside its own package.